### PR TITLE
Updated the relative link to the IDM docs in breadcrumbs

### DIFF
--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -8,7 +8,7 @@
 
 <div role="navigation" aria-label="breadcrumbs navigation">
   <ul class="wy-breadcrumbs">
-  <li><a href="../index.html">IDM docs</a> &raquo;</li>
+  <li><a href="https://idmod.org/documentation">IDM docs</a> &raquo;</li>
     <li><a href="{{ pathto(master_doc) }}">CMS</a> &raquo;</li>
       {% for doc in parents %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>


### PR DESCRIPTION
Now that the docs are hosted on Read the Docs, we need a full path to https://idmod.org/documentation in the breadcrumbs.